### PR TITLE
fix(dependabot): 'prettier'を一旦無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     target-branch: 'main'
     ignore:
       - dependency-name: '@types/node'
+      - dependency-name: 'prettier'


### PR DESCRIPTION
'prettier-plugin-tailwindcss'がまだ3.0に対応できてないので、一旦バージョンロック