### PR TITLE
chore: Remove unnecessary env-file flag from deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit-ui": "vitest --coverage.enabled=true --ui",
     "update:ncu": "ncu -ui",
     "update:nuxi": "nuxi upgrade -f",
-    "deploy": "node --env-file=.env --experimental-strip-types commands/deploy.ts"
+    "deploy": "node --experimental-strip-types commands/deploy.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "7.14.0",


### PR DESCRIPTION
### 📚 説明

Eliminate the redundant `--env-file` flag from the deploy script to streamline the deployment process.