### PR TITLE
chore: Remove deprecated security headers and add nitro prerender configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -63,6 +63,9 @@ export default defineNuxtConfig({
     },
   },
   compatibilityDate: '2024-11-01',
+  nitro: {
+    prerender: { autoSubfolderIndex: false },
+  },
   typescript: {
     tsConfig: { compilerOptions: { noUncheckedIndexedAccess: true } },
   },

--- a/public/_headers
+++ b/public/_headers
@@ -1,9 +1,0 @@
-/*
-  Cross-Origin-Embedder-Policy: require-corp
-  Cross-Origin-Opener-Policy: same-origin
-  Cross-Origin-Resource-Policy: same-origin
-  Referrer-Policy: no-referrer
-  X-Content-Type-Options: nosniff
-  X-Frame-Options: DENY
-  X-Permitted-Cross-Domain-Policies: none
-  X-XSS-Protection: 0


### PR DESCRIPTION
Eliminate outdated security headers from the _headers file and introduce nitro prerender settings in the nuxt.config.ts file.